### PR TITLE
feat: Add multi-arch (AMD64/ARM64) Docker builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,20 +45,25 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 20.10.18
       - attach_workspace:
           at: ~/
       - run:
           name: Login to Dockerhub
           command: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Load docker image
-          command: docker load -i flexo-mms-store-service.tar
+          name: Create multi-arch builder
+          command: |
+            docker buildx create --name multiarch --use || docker buildx use multiarch
+            docker buildx inspect --bootstrap
       - run:
-          name: Tag docker image
-          command: docker tag openmbee/flexo-mms-store-service:latest openmbee/flexo-mms-store-service:${CIRCLE_BRANCH#*/}-SNAPSHOT
-      - run:
-          name: Deploy snapshot to Dockerhub
-          command: docker push openmbee/flexo-mms-store-service:${CIRCLE_BRANCH#*/}-SNAPSHOT
+          name: Build and push multi-arch docker image
+          command: |
+            cp src/main/resources/application.conf.example ./src/main/resources/application.conf
+            docker buildx build --platform linux/amd64,linux/arm64 \
+              -t openmbee/flexo-mms-store-service:${CIRCLE_BRANCH#*/}-SNAPSHOT \
+              -t openmbee/flexo-mms-store-service:latest \
+              --push .
   deploy_release:
     executor:
       name: docker/docker
@@ -66,23 +71,25 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 20.10.18
       - attach_workspace:
           at: ~/
       - run:
           name: Login to Dockerhub
           command: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Load docker image
-          command: docker load -i flexo-mms-store-service.tar
+          name: Create multi-arch builder
+          command: |
+            docker buildx create --name multiarch --use || docker buildx use multiarch
+            docker buildx inspect --bootstrap
       - run:
-          name: Tag docker image
-          command: docker tag openmbee/flexo-mms-store-service:latest openmbee/flexo-mms-store-service:${CIRCLE_TAG}
-      - run:
-          name: Deploy release to dockerhub
-          command: docker push openmbee/flexo-mms-store-service:${CIRCLE_TAG}
-      - run:
-          name: Deploy release as latest to dockerhub
-          command: docker push openmbee/flexo-mms-store-service:latest
+          name: Build and push multi-arch release
+          command: |
+            cp src/main/resources/application.conf.example ./src/main/resources/application.conf
+            docker buildx build --platform linux/amd64,linux/arm64 \
+              -t openmbee/flexo-mms-store-service:${CIRCLE_TAG} \
+              -t openmbee/flexo-mms-store-service:latest \
+              --push .
 
 workflows:
   version: 2


### PR DESCRIPTION
- Replace docker build with docker buildx for multi-platform support
- Build for linux/amd64 and linux/arm64 platforms
- Update deploy_snapshot and deploy_release jobs
- Push both arch images with single manifest